### PR TITLE
feat: implement Client

### DIFF
--- a/Client.cpp
+++ b/Client.cpp
@@ -32,14 +32,16 @@ void Client::appendChunked(const Buffer &newRead)
 
 void Client::appendContentLength(const Buffer &newRead)
 {
-	static size_t			contentLength = requestObj.getContentLength();
+	static size_t			contentLength = 0;
 	RequestLexer::Tokens	tokens;
 
+	contentLength += newRead.size();
 	request.append(newRead);
 	if (request.size() >= contentLength)
 	{
 		tokens = RequestLexer::bodyLineTokenize(request);
 		RequestParser::bodyLineParsing(tokens, requestObj);
+		contentLength = 0;
 		state = STATE_COMPLETE;
 	}
 }

--- a/Client.cpp
+++ b/Client.cpp
@@ -26,7 +26,6 @@ void Client::appendChunked(const Buffer &newRead)
 	{
 		tokens = RequestLexer::bodyLineTokenize(request);
 		RequestParser::bodyLineParsing(tokens, requestObj);
-		request.clear();
 		state = STATE_COMPLETE;
 	}
 }
@@ -41,7 +40,6 @@ void Client::appendContentLength(const Buffer &newRead)
 	{
 		tokens = RequestLexer::bodyLineTokenize(request);
 		RequestParser::bodyLineParsing(tokens, requestObj);
-		request.clear();
 		state = STATE_COMPLETE;
 	}
 }
@@ -55,7 +53,8 @@ void Client::checkMessageBodyFormat()
 		state = STATE_REQUEST_CHUNKED;
 	else if (requestObj.getContentLength())
 		state = STATE_REQUEST_CONTENT_LENGTH;
-	request.clear();
+	else
+		state = STATE_COMPLETE;
 }
 
 std::string Client::convertToString(const size_t &contentLength)

--- a/Client.cpp
+++ b/Client.cpp
@@ -32,16 +32,13 @@ void Client::appendChunked(const Buffer &newRead)
 
 void Client::appendContentLength(const Buffer &newRead)
 {
-	static size_t			contentLength = 0;
 	RequestLexer::Tokens	tokens;
 
-	contentLength += newRead.size();
 	request.append(newRead);
-	if (request.size() >= contentLength)
+	if (request.size() >= requestObj.getContentLength())
 	{
 		tokens = RequestLexer::bodyLineTokenize(request);
 		RequestParser::bodyLineParsing(tokens, requestObj);
-		contentLength = 0;
 		state = STATE_COMPLETE;
 	}
 }

--- a/Client.cpp
+++ b/Client.cpp
@@ -4,6 +4,9 @@
 #include <stdexcept>
 #include <sstream>
 
+Client::Client() : state(STATE_REQUEST_FIELD_LINE), response("")
+{ }
+
 void Client::appendEssentialPart(const Buffer &newRead)
 {
 	size_t  startPos = request.size() - 3;  // "3" means \r\n\r was in previous buffer and last \n is in current buffer.

--- a/Client.cpp
+++ b/Client.cpp
@@ -1,0 +1,136 @@
+#include "Client.hpp"
+#include "RequestParser.hpp"
+#include "RequestLexer.hpp"
+#include <stdexcept>
+#include <sstream>
+
+void Client::appendEssentialPart(const Message &newRead)
+{
+	size_t  startPos = request.size() - 3;  // "3" means \r\n\r was in previous buffer and last \n is in current buffer.
+
+	request.append(newRead);
+	if (request.find(CRLFCRLF, startPos) == std::string::npos)
+		checkMessageBodyFormat();
+}
+
+void Client::appendChunked(const Message &newRead)
+{
+	size_t					startPos = request.size() - 3;
+	RequestLexer::Tokens	tokens;
+
+	request.append(newRead);
+	if (request.find(CRLFCRLF, startPos) != std::string::npos)
+	{
+		tokens = RequestLexer::bodyLineTokenize(request);
+		RequestParser::bodyLineParsing(tokens, requestObj);
+		request.clear();
+		state = STATE_COMPLETE;
+	}
+}
+
+void Client::appendContentLength(const Message &newRead)
+{
+	static size_t			contentLength = requestObj.getContentLength();
+	RequestLexer::Tokens	tokens;
+
+	request.append(newRead);
+	if (request.size() >= contentLength)
+	{
+		tokens = RequestLexer::bodyLineTokenize(request);
+		RequestParser::bodyLineParsing(tokens, requestObj);
+		request.clear();
+		state = STATE_COMPLETE;
+	}
+}
+
+void Client::checkMessageBodyFormat()
+{
+	RequestLexer::Tokens	tokens = RequestLexer::startLineHeaderLineTokenize(request);
+
+	requestObj = RequestParser::startLineHeaderLineParsing(tokens);
+	if (requestObj.getChunked())
+		state = STATE_REQUEST_CHUNKED;
+	else if (requestObj.getContentLength())
+		state = STATE_REQUEST_CONTENT_LENGTH;
+	request.clear();
+}
+
+std::string Client::convertToString(const size_t &contentLength)
+{
+	std::stringstream	ss;
+
+	ss << contentLength;
+	return (ss.str());
+}
+
+void Client::appendCGI(const Message &newRead)
+{
+	static size_t	contentLength = 0;
+	static Message	body;
+
+	if (newRead.size() == 0)	// this means that client has closed its socket.
+	{
+		responseObj.setBody(body);
+		responseObj.setContentLength(convertToString(contentLength));
+		contentLength = 0;
+		state = STATE_COMPLETE;
+		return;
+	}
+	body.append(newRead);
+	contentLength += newRead.size();
+}
+
+// Client::Client(SocketAddr connectedServer) : connectedServer(connectedServer)
+// { }
+
+void Client::appendMessage(const Message &newRead)
+{
+	switch (state)
+	{
+		case STATE_REQUEST_FIELD_LINE:
+			return (appendEssentialPart(newRead));
+		case STATE_REQUEST_CHUNKED:
+			return (appendChunked(newRead));
+		case STATE_REQUEST_CONTENT_LENGTH:
+			return (appendContentLength(newRead));
+	}
+}
+
+void Client::setRequestObj(Request requestObj)
+{
+	this->requestObj = requestObj;
+}
+
+const Request &Client::getRequestObj()
+{
+	return (requestObj);
+}
+
+void Client::setResponseObj(Response responseObj)
+{
+	this->responseObj = responseObj;
+}
+
+const Response &Client::getResponseObj()
+{
+	return (responseObj);
+}
+
+const char *Client::getResponseMessage()
+{
+	return (response);
+}
+
+const char	Client::updateResponsePointer(const ssize_t &sent)
+{
+	response += sent;
+	return (*response);
+}
+
+//TODO: requestObj, responseObj도 초기화해야 하나? 이 둘은 이 클래스에서 다루진 않고 외부 클래스가 반환하는 값을 저장할 뿐이므로 초기화는 필요없어 보인다.
+void Client::reset()
+{
+	state = STATE_REQUEST_FIELD_LINE;
+	request.clear();
+	response = EMPTY_STRING;
+}

--- a/Client.hpp
+++ b/Client.hpp
@@ -21,8 +21,8 @@
 class Client
 {
 public:
-	typedef std::string				RequestString, Message, Host, Port;
-	typedef char *					ResponseString;
+	typedef std::string				RequestString, Buffer, Host, Port;
+	typedef const char *			ResponseString;
 	typedef std::pair<Host, Port>	SocketAddr;
 
 private:
@@ -34,24 +34,25 @@ private:
 	Response		responseObj;
 
 private:
-	void		appendEssentialPart(const Message &newRead);
-	void		appendChunked(const Message &newRead);
-	void		appendContentLength(const Message &newRead);
+	void		appendEssentialPart(const Buffer &newRead);
+	void		appendChunked(const Buffer &newRead);
+	void		appendContentLength(const Buffer &newRead);
 	void		checkMessageBodyFormat();
 	std::string	convertToString(const size_t &contentLength);
 
 public:
 	// Client(SocketAddr connectedServer);
 	const char		*getResponseMessage();
-
+	void			setResponseMessage(const Buffer &response);
 	const char		updateResponsePointer(const ssize_t &sent);
 	void			reset();
-	void			appendCGI(const Message &newRead);
-	void			appendMessage(const Message &newRead);
-	
-	void			setRequestObj(Request requestObj);
-	const Request	&getRequestObj();
-	void			setResponseObj(Response responseObj);
-	const Response	&getResponseObj();
+	void			appendCGI(const Buffer &newRead);
+	void			appendMessage(const Buffer &newRead);
+	bool			isComplete();
+	void			setCGIState();
+	// void			setRequestObj(Request requestObj);
+	const Request	&getRequestObject();
+	void			setResponseObject(Response responseObj);
+	const Response	&getResponseObject();
 };
 #endif

--- a/Client.hpp
+++ b/Client.hpp
@@ -42,6 +42,7 @@ private:
 
 public:
 	// Client(SocketAddr connectedServer);
+	Client();
 	const char		*getResponseMessage();
 	void			setResponseMessage(const Buffer &response);
 	const char		updateResponsePointer(const ssize_t &sent);

--- a/Client.hpp
+++ b/Client.hpp
@@ -1,7 +1,57 @@
 #ifndef CLIENT_HPP
 # define CLIENT_HPP
+
+# include <string>
+# include <utility>
+# include <sys/types.h>
+# include "Request.hpp"
+# include "Response.hpp"
+
+# define CRLFCRLF							"\r\n\r\n"
+# define EMPTY_STRING						""
+
+# define STATE_REQUEST_FIELD_LINE			1
+# define STATE_REQUEST_CHUNKED				2
+# define STATE_REQUEST_CONTENT_LENGTH		4
+# define STATE_RESPONSE_CGI					8
+# define STATE_COMPLETE						16
+
+# define CONTENT_LENGTH_EXCEPTION_MESSAGE	"TOO LONG CLIENT MESSAGE BODY!"
+
 class Client
 {
+public:
+	typedef std::string				RequestString, Message, Host, Port;
+	typedef char *					ResponseString;
+	typedef std::pair<Host, Port>	SocketAddr;
 
+private:
+	// SocketAddr		connectedServer;
+	unsigned short	state;
+	RequestString	request;
+	ResponseString	response;
+	Request			requestObj;
+	Response		responseObj;
+
+private:
+	void		appendEssentialPart(const Message &newRead);
+	void		appendChunked(const Message &newRead);
+	void		appendContentLength(const Message &newRead);
+	void		checkMessageBodyFormat();
+	std::string	convertToString(const size_t &contentLength);
+
+public:
+	// Client(SocketAddr connectedServer);
+	const char		*getResponseMessage();
+
+	const char		updateResponsePointer(const ssize_t &sent);
+	void			reset();
+	void			appendCGI(const Message &newRead);
+	void			appendMessage(const Message &newRead);
+	
+	void			setRequestObj(Request requestObj);
+	const Request	&getRequestObj();
+	void			setResponseObj(Response responseObj);
+	const Response	&getResponseObj();
 };
 #endif

--- a/RequestParser/RequestLexer.cpp
+++ b/RequestParser/RequestLexer.cpp
@@ -185,7 +185,7 @@ RequestLexer::Tokens RequestLexer::httpTokenize(std::string inputRequestMessage)
 }
 
 
-RequestLexer::Tokens RequestLexer::startLineHeaderLineTokenize(std::string inputRequestMessage)
+RequestLexer::Tokens RequestLexer::startLineHeaderLineTokenize(const std::string &inputRequestMessage)
 {
 	Tokens	tokens;
 
@@ -202,7 +202,7 @@ RequestLexer::Tokens RequestLexer::startLineHeaderLineTokenize(std::string input
 	return (tokens);
 }
 
-RequestLexer::Tokens RequestLexer::bodyLineTokenize(std::string inputRequestMessage)
+RequestLexer::Tokens RequestLexer::bodyLineTokenize(const std::string &inputRequestMessage)
 {
 	Tokens	tokens;
 

--- a/RequestParser/RequestLexer.hpp
+++ b/RequestParser/RequestLexer.hpp
@@ -49,8 +49,8 @@ class RequestLexer
 		
 	public:
 		static Tokens httpTokenize(std::string inputRequestMessage);
-		static Tokens startLineHeaderLineTokenize(std::string inputRequestMessage);
-		static Tokens bodyLineTokenize(std::string inputRequestMessage);
+		static Tokens startLineHeaderLineTokenize(const std::string &inputRequestMessage);
+		static Tokens bodyLineTokenize(const std::string &inputRequestMessage);
 };
 
 #endif


### PR DESCRIPTION
- [x] 버퍼사이즈만큼 읽어온 요청 메시지의 일부를 누적해서 저장하는 기능
- [x] 요청 메시지를 모두 읽었는지 판단해 Request 객체로 파싱하는 기능
- [x] 해당 클라이언트의 요청과 응답을 외부에서 활용하기 위한 getter, setter
- [x] CGI가 반환하는 문자열을 Response 객체의 message body로 저장하는 기능 