### PR TITLE
fix: 로직 오류 수정 및 리팩토링

### DIFF
--- a/Client/inc/Client.hpp
+++ b/Client/inc/Client.hpp
@@ -8,7 +8,7 @@
 # include "Response.hpp"
 
 # define CRLFCRLF							"\r\n\r\n"
-
+# define EMPTY_STRING						""
 # define STATE_REQUEST_FIELD_LINE			1
 # define STATE_REQUEST_CHUNKED				2
 # define STATE_REQUEST_CONTENT_LENGTH		4
@@ -37,7 +37,7 @@ private:
 	void		appendEssentialPart(const Message &newRead);
 	void		appendChunked(const Message &newRead);
 	void		appendContentLength(const Message &newRead);
-	void		checkMessageBodyFormat();
+	void		checkMessageBodyFormat(const size_t &headerLineEndPos);
 	std::string	convertToString(const size_t &contentLength);
 
 public:
@@ -51,7 +51,7 @@ public:
 	bool			isComplete();
 	void			setCGIState();
 	void			setDisconnectedState();
-	
+	bool			isDisconnected();
 	const Request	&getRequestObject();
 	void			setResponseObject(Response responseObj);
 	const Response	&getResponseObject();

--- a/Client/src/Client.cpp
+++ b/Client/src/Client.cpp
@@ -70,18 +70,16 @@ std::string Client::convertToString(const size_t &contentLength)
 void Client::appendCGI(const Message &newRead)
 {
 	static size_t	contentLength = 0;
-	static Message	body;
 
 	if (newRead.size() == 0)	// this means that client has closed its socket.
 	{
-		responseObj.setBody(body);
+		responseObj.setBody(message);
 		responseObj.setContentLength(convertToString(contentLength));
 		contentLength = 0;
-		body.clear();
 		state = STATE_COMPLETE;
 		return;
 	}
-	body.append(newRead);
+	message.append(newRead);
 	contentLength += newRead.size();
 }
 
@@ -107,6 +105,7 @@ bool Client::isComplete()
 
 void Client::setCGIState()
 {
+	message.clear();
 	state = STATE_RESPONSE_CGI;
 }
 

--- a/Client/src/Client.cpp
+++ b/Client/src/Client.cpp
@@ -10,52 +10,53 @@ Client::Client() : state(STATE_REQUEST_FIELD_LINE)
 void Client::appendEssentialPart(const Message &newRead)
 {
 	size_t  startPos = message.size() - 3;  // "3" means \r\n\r was in previous buffer and last \n is in current buffer.
+	size_t	headerLineEndPos;
 
 	if (message.size() < startPos)
 		startPos = 0;
 	message.append(newRead);
-	if (message.find(CRLFCRLF, startPos) != std::string::npos)
-		checkMessageBodyFormat();
+	headerLineEndPos = message.find(CRLFCRLF, startPos);
+	if (headerLineEndPos != std::string::npos)
+		checkMessageBodyFormat(headerLineEndPos + 4);
 }
 
 void Client::appendChunked(const Message &newRead)
 {
-	size_t					startPos = message.size() - 3;
-	RequestLexer::Tokens	tokens;
-
 	message.append(newRead);
-	if (message.find(CRLFCRLF, startPos) != std::string::npos)
+	if (message.find(CRLFCRLF, message.size() - 3) != std::string::npos)
 	{
-		tokens = RequestLexer::bodyLineTokenize(message);
-		RequestParser::bodyLineParsing(tokens, requestObj);
+		RequestParser::bodyLineParsing(RequestLexer::bodyLineTokenize(message), requestObj);
 		state = STATE_COMPLETE;
 	}
 }
 
 void Client::appendContentLength(const Message &newRead)
 {
-	RequestLexer::Tokens	tokens;
-
 	message.append(newRead);
 	if (message.size() >= requestObj.getContentLength())
 	{
-		tokens = RequestLexer::bodyLineTokenize(message);
-		RequestParser::bodyLineParsing(tokens, requestObj);
+		RequestParser::bodyLineParsing(RequestLexer::bodyLineTokenize(message), requestObj);
 		state = STATE_COMPLETE;
 	}
 }
 
-void Client::checkMessageBodyFormat()
+void Client::checkMessageBodyFormat(const size_t &headerLineEndPos)
 {
 	RequestLexer::Tokens	tokens = RequestLexer::startLineHeaderLineTokenize(message);
 
-	requestObj = RequestParser::startLineHeaderLineParsing(tokens);
+	state = STATE_COMPLETE;
+	RequestParser::startLineHeaderLineParsing(tokens, requestObj);
+	message.erase(0, headerLineEndPos);
 	if (requestObj.getChunked())
+	{
 		state = STATE_REQUEST_CHUNKED;
-	else if (requestObj.getContentLength())
+		return (appendChunked(EMPTY_STRING));
+	}
+	if (requestObj.getContentLength())
+	{
 		state = STATE_REQUEST_CONTENT_LENGTH;
-	else
-		state = STATE_COMPLETE;
+		return (appendContentLength(EMPTY_STRING));
+	}
 }
 
 std::string Client::convertToString(const size_t &contentLength)
@@ -76,6 +77,7 @@ void Client::appendCGI(const Message &newRead)
 		responseObj.setBody(body);
 		responseObj.setContentLength(convertToString(contentLength));
 		contentLength = 0;
+		body.clear();
 		state = STATE_COMPLETE;
 		return;
 	}
@@ -111,6 +113,11 @@ void Client::setCGIState()
 void Client::setDisconnectedState()
 {
 	state = STATE_DISCONNECTED;
+}
+
+bool Client::isDisconnected()
+{
+	return (state == STATE_DISCONNECTED);
 }
 
 const Request &Client::getRequestObject()
@@ -150,10 +157,11 @@ char	Client::updateResponsePointer(const ssize_t &sent)
 	return (*response);
 }
 
-//TODO: requestObj, responseObj도 초기화해야 하나? 이 둘은 이 클래스에서 다루진 않고 외부 클래스가 반환하는 값을 저장할 뿐이므로 초기화는 필요없어 보인다.
 void Client::reset()
 {
 	state = STATE_REQUEST_FIELD_LINE;
 	message.clear();
 	response = 0;
+	requestObj = Request();
+	responseObj = Response();
 }

--- a/Config/src/ConfigServer.cpp
+++ b/Config/src/ConfigServer.cpp
@@ -21,7 +21,6 @@ void ConfigServer::setUndeclaredLocationDirectives(const ConfigServer &server)
 
 ConfigServer::const_iterator ConfigServer::findLocation(const Route &requested) const
 {
-	//TODO: 모든 location uri를 이터레이터로 돌면서 given이 해당 location uri로 시작하는지 체크하고, 그러한 location uri들 중에 가장 길이가 긴 uri를 반환한다.
 	const_iterator	ret = locationMap.end();
 
 	for (const_iterator cIt = locationMap.begin(); cIt != locationMap.end(); cIt++)

--- a/ConfigParser/src/ConfigLexer.cpp
+++ b/ConfigParser/src/ConfigLexer.cpp
@@ -1,5 +1,6 @@
 #include "ConfigLexer.hpp"
 #include <stdexcept>
+#include <cstring>
 
 // static members initialization
 const ConfigLexer::Delimiter	ConfigLexer::WHITESPACES = WHITESPACES_LITERAL;
@@ -90,7 +91,7 @@ ConfigLexer::Tokens ConfigLexer::tokenize(const char *filePath)
 	Tokens	tokens;
 
 	configFile.open(filePath);
-	if (!configFile.good())
+	if (!configFile.good() || filePath[std::strlen(filePath) - 1] == '/')
 		throw (std::invalid_argument(FILEPATH_EXCEPT_MSG));
 	while (!configFile.eof())
 		processToken(tokens);

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CXXFLAGS 	= -Wall -Wextra -Werror -std=c++98
 INCLUDES 	= Client/inc Config/inc ConfigParser/inc RequestParser/inc Server/inc
 CXXFLAGS 	+= $(addprefix -I, $(INCLUDES))
 
-SRCS 		= $(wildcard */src/*.cpp) main.cpp
+SRCS 		= $(filter-out Tester/*, $(wildcard */src/*.cpp)) main.cpp
 OBJS 		= $(SRCS:.cpp=.o)
 
 all: $(NAME)

--- a/RequestParser/inc/RequestParser.hpp
+++ b/RequestParser/inc/RequestParser.hpp
@@ -16,65 +16,59 @@ class RequestParser
 {
   typedef RequestLexer::Tokens Tokens;
   typedef RequestLexer::Token Token;
-  typedef RequestLexer::MandatoryHeaderMap MandatoryHeaderMap;
   typedef RequestLexer::SizeType SizeType;
-  typedef std::string Method, Space, HttpVersion, FieldName, FieldValue, Port, BodyType;
+  typedef std::string Space, HttpVersion, FieldName, FieldValue, Port, BodyType;
   typedef int HeaderType;
 
 
   private:
     //startline 검사
-    static void startLineValidity(Tokens &tokens);
-    static void headerLineValidity(Tokens &tokens);
-    static void bodyLineValidity(Tokens &tokens);
-    static void errorHandling(const char *code);
-    static void throwError(const char *code, std::string errorReason);
+    static void startLineValidity(Tokens &tokens, Request &request);
+    static void headerLineValidity(const Tokens &tokens, Request &request);
+    static void bodyLineValidity(const Tokens &tokens, Request &request);
+    static void errorHandling(const char *code, Request &request);
+    static void throwError(const char *code, const std::string &errorReason);
 
-    static void previousErrorCheck(Tokens &tokens);
-    static bool isMethod(std::string str);
-    static bool isSpace(std::string str);
-    static bool isQueryString(std::string str);
-    static void queryStringSyntaxCheck(std::string queryString);
-    static bool isHttpVersion(std::string str);
-    static Request::MethodType  settingMethod(std::string str);
-    static void headerCheck(Token &fieldNameToken, Token &fieldValueToken);
-    static void mandatoryHeaderValidity(HeaderType fieldNameType, FieldName fieldName, HeaderType fieldValueType, FieldValue fieldValue);
-    static void nonMandatoryHeaderValidity(FieldName fieldName, FieldValue fieldValue);
-    static void hostValidity(FieldValue fieldValue);
-    static void transferEncodingValidity(FieldValue fieldValue);
-    static void contentLengthValidity(FieldValue fieldValue);
-    static void cookieValidity(FieldValue fieldValue);
-    static void contentTypeValidity(FieldValue fieldValue, HeaderType fieldValueType);
-    static void connectionValidity(FieldValue fieldValue);
-    static void extractMultipartFormDataId(FieldValue fieldValue);
-    static bool isFieldNameSpace(FieldName fieldName);
-    static void hostPortCheck(Port port);
-    static bool isInMandatoryHeader(Tokens &tokens);
-    static Request::FieldValueListType splitValue(std::string input, char delimiter);
-    static std::string trimAll(std::string &str);
+    static void previousErrorCheck(const Tokens &tokens);
+    static bool isMethod(const std::string &str);
+    static bool isSpace(const std::string &str);
+    static bool isQueryString(const std::string &str);
+    static void queryStringSyntaxCheck(const std::string &queryString, Request &request);
+    static bool isHttpVersion(const std::string &str);
+    static Request::MethodType  settingMethod(const std::string &str);
+    static void headerCheck(const Token &fieldNameToken, Token &fieldValueToken, Request &request);
+    static void mandatoryHeaderValidity(const Token &fieldName, Token &fieldValue, Request &request);
+    static void nonMandatoryHeaderValidity(const FieldName &fieldName, FieldValue &fieldValue, Request &request);
+    static void hostValidity(const FieldValue &fieldValue, Request &request);
+    static void transferEncodingValidity(const FieldValue &fieldValue, Request &request);
+    static void contentLengthValidity(const FieldValue &fieldValue, Request &request);
+    static void cookieValidity(FieldValue &fieldValue, Request &request);
+    static void contentTypeValidity(FieldValue &fieldValue, const HeaderType &fieldValueType, Request &request);
+    static void connectionValidity(FieldValue &fieldValue, Request &request);
+    static void extractMultipartFormDataId(const FieldValue &fieldValue, Request &request);
+    static bool isFieldNameSpace(const FieldName &fieldName);
+    static void hostPortCheck(const Port &port, Request &request);
+    static bool isInMandatoryHeader(const Tokens &tokens);
+    static Request::FieldValueListType splitValue(const std::string &input, char delimiter);
+    static std::string &trimAll(std::string &str);
 
-    static void inputBodyData(Tokens &tokens);
-    static void chunkedProcess();
-    static Request::ChunkedListType splitBodyData(std::string input);
-    static double chunkedLengthConvert(std::string str);
-    static void multipartFormDataIdProcess();
-    static std::string ft_toLower(std::string str);
-    static std::string getBodyLine();
-    static void chunkedContentLengthOverlapCheck(Tokens &tokens);
+    static void inputBodyData(const Tokens &tokens, Request &request);
+    static void chunkedProcess(Request &request);
+    static Request::ChunkedListType splitBodyData(const std::string &input);
+    static double chunkedLengthConvert(const std::string &str);
+    static void multipartFormDataIdProcess(Request &request);
+    static std::string &ft_toLower(std::string &str);
+    static std::string getBodyLine(BodyType &body);
+    static void chunkedContentLengthOverlapCheck(const Tokens &tokens, Request &request);
 
   private:	// constants
-		static const Method	METHOD;
     static const Space	SPACE;
     static const HttpVersion HTTPVERSION;
 
-  private:
-		static Request	request;
-    static BodyType bodyTemp;
-
   public:
-    static Request httpParser(Tokens &tokens);
-    static Request startLineHeaderLineParsing(Tokens &tokens);
-    static Request bodyLineParsing(Tokens &tokens, Request &inputRequest);
+    // static Request httpParser(Tokens &tokens);//TODO: remove
+    static void startLineHeaderLineParsing(Tokens &tokens, Request &request);
+    static void bodyLineParsing(const Tokens &tokens, Request &request);
 };
 
 

--- a/Server/inc/Server.hpp
+++ b/Server/inc/Server.hpp
@@ -18,10 +18,11 @@
 # define BUFFER_SIZE					8000
 # define CHAR_NULL						'\0'
 # define RECV_EXCEPTION_MESSAGE			"recv() ERROR!"
+# define READ_EXCEPTION_MESSAGE			"read() ERROR!"
 # define SEND_EXCEPTION_MESSAGE			"send() ERROR!"
 # define DISCONNECTED_MESSAGE			"CLIENT DISCONNECTED!"
-# define DISCONNECTING_MESSAGE			"DISCONNECTED CONNECTION!"
-# define ACCEPT_EXCEPTION_MESSAGE		"accpet() ERROR!"
+# define DISCONNECTING_MESSAGE			"SERVER DISCONNECTED!"
+# define ACCEPT_EXCEPTION_MESSAGE		"accept() ERROR!"
 # define EPOLL_WAIT_EXCEPTION_MESSAGE	"epoll_wait() ERROR!"
 
 class Server
@@ -56,13 +57,12 @@ private:
 	int				waitIOEventOccurrence(const FileDescriptor &epoll, epoll_event *events);
 	void			handleIOEvent(const FileDescriptor &epoll, const epoll_event &event);
 	void			acceptNewClient(const FileDescriptor &epoll, const FileDescriptor &server);
-	void			disconnectClient(const FileDescriptor &epoll, const FileDescriptor &client, const char *reason);
+	void			disconnect(const FileDescriptor &epoll, const FileDescriptor &client, const char *reason);
 	void			receiveRequest(const FileDescriptor &epoll, const FileDescriptor &client, Client &target);
 	void			receiveCGI(const FileDescriptor &epoll, const FileDescriptor &pipe, Client &target);
 	void			processRequest(const FileDescriptor &epoll, const FileDescriptor &client, Client &target);
 	void			sendData(const FileDescriptor &epoll, const FileDescriptor &client);
 	void			receiveData(const FileDescriptor &epoll, const FileDescriptor &fd, Client &target);
-	void			waitChildProcessNonblocking();
 	void			handleConnection(const FileDescriptor &epoll, const FileDescriptor &client);
 
 public:

--- a/Server/src/Server.cpp
+++ b/Server/src/Server.cpp
@@ -194,7 +194,6 @@ void Server::sendData(const FileDescriptor &epoll, const FileDescriptor &client)
 	const char	*response = target.getResponseMessage();
 	ssize_t		sent = send(client, response, std::strlen(response), MSG_DONTWAIT);
 
-	std::cerr << sent << std::endl;
 	if (sent < 0)
 		return (disconnect(epoll, client, SEND_EXCEPTION_MESSAGE)); //TODO: 5xx server error?
 	if (target.updateResponsePointer(sent) == CHAR_NULL)


### PR DESCRIPTION
- [x] (Server.hpp): 서버가 연결을 끊을 때 출력하는 메시지 변경
- [x] (Server::waitChildProcessNonBlocking): 함수 제거
- [x] (Server::processRequest): cgiPipe를 non-blocking 모드로 설정
- [x] (Server::createEpollObject): config가 빈 파일이어도 서버가 돌아가게 epoll_create에 0 이상을 인자로 전달
- [x] (Server::disconnectClient): 함수명 수정
- [x] (Client::appendCGI): CGI 처리가 끝나면 body 변수를 비우는 로직 추가
- [x] (Client::reset): 연결 종료시 requestObj, responseObj도 초기화
- [x] (Client::isDisconnected): 클라이언트의 연결이 끊어진 상태인지 확인하는 함수 추가
- [x] (Client::checkMessageBodyFormat): 로직 오류 수정 및 분기문 수 줄이기
- [x] (Client.cpp): 메서드 라인 수 줄이기
- [x] (ConfigLexer::tokenize): 파일 경로가 디렉터리일 때 예외처리 로직 추가
- [x] (RequestParser): static member variables 제거 및 메서드 파라미터 활용
- [x] (RequestParser): 메서드 파라미터들 중 가능한 것들 const, & 타입으로 변경
- [x] (RequestParser): 사용하지 않는 typedef들 제거
- [x] (RequestParser): 메서드 라인 수 줄이기