### PR TITLE
refactor: refactor RequestLexer

### DIFF
--- a/RequestParser/inc/RequestLexer.hpp
+++ b/RequestParser/inc/RequestLexer.hpp
@@ -17,7 +17,7 @@ class RequestLexer
 {
 	public:
 		typedef std::string::size_type						SizeType;
-		typedef std::string												Delimiter, Lexeme, FieldName, FieldValue;
+		typedef std::string												Delimiter, Lexeme, FieldName, FieldValue, StatusCode;
 		typedef int																TokenType;
 		typedef std::pair<TokenType, Lexeme>			Token;
 		typedef std::list<Token>									Tokens;
@@ -26,30 +26,28 @@ class RequestLexer
 
 	private:	// constants
 		static const Delimiter	WHITESPACES;
+		static const StatusCode	CLIENT_ERROR;
+		static const char		*CRLF;
+	// private:
+		// static std::string	requestMessage;
 
 	private:
-		static std::string	requestMessage;
-
-	private:
-		static void				startLineTokenize(Tokens &tokens);
-		static void				headerLineTokenize(Tokens &tokens);
-		static void				bodyLineTokenize(Tokens &tokens);
-		static void				errorHandling(Tokens &tokens, const char *code);
+		static void				startLineTokenize(Tokens &tokens, std::string &requestMessage);
+		static void				headerLineTokenize(Tokens &tokens, std::string &requestMessage);
+		static void				bodyLineDoTokenize(Tokens &tokens, const std::string &requestMessage);
+		static void				errorHandling(Tokens &tokens, const std::string &code);
 		
-		static std::string		getLine();
-		static HeaderField		colonSplit(std::string str, char delimiter);
+		static std::string		getLine(std::string &requestMessage);
+		static HeaderField		colonSplit(const std::string &str, const char delimiter);
 		static TokenType evaluateDelimiterLexeme(const Delimiter &delimiter);
-		static void addToken(Tokens &tokens, Lexeme lexeme, Lexeme delimiter);
-		static bool isDelimiter(char c);
-		static bool isCRLF();
-		static void	mandatoryHeaderProcess(Tokens &tokens, HeaderField &headerField, MandatoryHeaderMap mandatoryHeaderMap);
-		static int	isMandatoryHeader(MandatoryHeaderMap mandatoryHeader, std::string str);
+		static void addToken(Tokens &tokens, Lexeme &lexeme, const Lexeme &delimiter);
+		static void	mandatoryHeaderProcess(Tokens &tokens, HeaderField &headerField, MandatoryHeaderMap &mandatoryHeaderMap);
 		static MandatoryHeaderMap mandatoryHeaderInitial();
-		static std::string ft_toLower(std::string str);
+		static std::string &ft_toLower(std::string &str);
 		
 	public:
-		static Tokens httpTokenize(std::string inputRequestMessage);
-		static Tokens startLineHeaderLineTokenize(const std::string &inputRequestMessage);
+		// static Tokens httpTokenize(std::string inputRequestMessage);
+		static Tokens startLineHeaderLineTokenize(std::string &inputRequestMessage);
 		static Tokens bodyLineTokenize(const std::string &inputRequestMessage);
 };
 

--- a/RequestParser/src/RequestLexer.cpp
+++ b/RequestParser/src/RequestLexer.cpp
@@ -1,29 +1,14 @@
 #include "RequestLexer.hpp"
+#include <algorithm>
 
-const char *g_CRLF = "\r\n";
-std::string	RequestLexer::requestMessage;
+const char 						*RequestLexer::CRLF = "\r\n";
 const RequestLexer::Delimiter	RequestLexer::WHITESPACES = WHITESPACES_LITERAL;
+const RequestLexer::StatusCode	RequestLexer::CLIENT_ERROR = "400";
 
-std::string RequestLexer::ft_toLower(std::string str)
+std::string &RequestLexer::ft_toLower(std::string &str)
 {
-  for (unsigned int i = 0; i < str.length(); i++) {
-    str[i] = std::tolower(str[i]);
-  }
-	return str;
-}
-
-bool RequestLexer::isDelimiter(char c)
-{
-    return (WHITESPACES.find(c) != std::string::npos);
-}
-
-bool RequestLexer::isCRLF()
-{
-	SizeType pos = requestMessage.find(g_CRLF);	
-	
-	if (pos == 0)
-		return true;
-	return false;
+	std::for_each(str.begin(), str.end(), ::tolower);
+	return (str);
 }
 
 RequestLexer::TokenType RequestLexer::evaluateDelimiterLexeme(const Delimiter &delimiter)
@@ -35,7 +20,7 @@ RequestLexer::TokenType RequestLexer::evaluateDelimiterLexeme(const Delimiter &d
 	return (ETC);
 }
 
-void RequestLexer::addToken(Tokens &tokens, Lexeme lexeme, Lexeme delimiter)
+void RequestLexer::addToken(Tokens &tokens, Lexeme &lexeme, const Lexeme &delimiter)
 {
 	if (lexeme.size())		
 		tokens.push_back(std::make_pair(STARTLINE_STR, lexeme));
@@ -43,39 +28,36 @@ void RequestLexer::addToken(Tokens &tokens, Lexeme lexeme, Lexeme delimiter)
 		tokens.push_back(std::make_pair(evaluateDelimiterLexeme(delimiter), ""));
 }
 
-RequestLexer::HeaderField	RequestLexer::colonSplit(std::string str, char delimiter)
+RequestLexer::HeaderField	RequestLexer::colonSplit(const std::string &str, const char delimiter)
 {	
 	SizeType pos = str.find(delimiter);	
-	SizeType len = str.length();
 
 	if (pos == std::string::npos)
-		throw ("400");
-	
-	return std::make_pair(str.substr(0, pos), str.substr(pos + 1, len));
+		throw (CLIENT_ERROR);
+	return (std::make_pair(str.substr(0, pos), str.substr(pos + 1, str.length())));
 }
 
-std::string	RequestLexer::getLine()
+std::string	RequestLexer::getLine(std::string &requestMessage)
 {	
-	SizeType pos = requestMessage.find(g_CRLF);
+	SizeType pos = requestMessage.find(CRLF);
 	std::string	line;
 	
 	if (pos == std::string::npos)
-		throw ("400");
+		throw (CLIENT_ERROR);
 	line = requestMessage.substr(0, pos);
-	requestMessage = requestMessage.substr(pos + 2, requestMessage.length());
-	return line;
+	requestMessage.erase(0, pos + 2);
+	return (line);
 }
 
-void	RequestLexer::startLineTokenize(Tokens &tokens)
+void	RequestLexer::startLineTokenize(Tokens &tokens, std::string &requestMessage)
 {	
-	std::string 			startLine = getLine();	
-	std::istringstream		ss(startLine); 
+	std::istringstream		ss(getLine(requestMessage)); 
 	char					currentChar = ss.get();
 	Lexeme	lexeme;		
 
 	while (!ss.eof() || currentChar != EOF)
 	{
-		if (!isDelimiter(currentChar))
+		if (WHITESPACES.find(currentChar) == std::string::npos)
 		{
 			lexeme.push_back(currentChar);
 			currentChar = ss.get();
@@ -111,12 +93,7 @@ RequestLexer::MandatoryHeaderMap RequestLexer::mandatoryHeaderInitial()
 	return mandatoryHeader;
 }
 
-int	RequestLexer::isMandatoryHeader(MandatoryHeaderMap mandatoryHeader, std::string str)
-{
-	return mandatoryHeader.count(str);
-}
-
-void	RequestLexer::mandatoryHeaderProcess(Tokens &tokens, HeaderField &headerField, MandatoryHeaderMap mandatoryHeaderMap)
+void	RequestLexer::mandatoryHeaderProcess(Tokens &tokens, HeaderField &headerField, MandatoryHeaderMap &mandatoryHeaderMap)
 {
 
 	std::string headerFieldLower = ft_toLower(headerField.first); //headerfield는 대소문자 구별이 없다. 소문자 기준으로 프로그램을 작성하였다.
@@ -129,18 +106,18 @@ void	RequestLexer::mandatoryHeaderProcess(Tokens &tokens, HeaderField &headerFie
 		tokens.push_back(std::make_pair(mandatoryHeaderMap[headerFieldLower + "_value"], headerField.second));
 }
 
-void	RequestLexer::headerLineTokenize(Tokens &tokens)
+void	RequestLexer::headerLineTokenize(Tokens &tokens, std::string &requestMessage)
 {	
 	std::string headerLine;
 	HeaderField	headerField;
 	Lexeme	lexeme;
 	MandatoryHeaderMap mandatoryHeader = mandatoryHeaderInitial();
 
-	while (!isCRLF())
+	while (requestMessage.find(CRLF) != 0)
 	{
-		headerLine = getLine();
+		headerLine = getLine(requestMessage);
 		headerField = colonSplit(headerLine, ':');
-		if (isMandatoryHeader(mandatoryHeader, ft_toLower(headerField.first)))
+		if (mandatoryHeader.find(ft_toLower(headerField.first)) != mandatoryHeader.end())
 			mandatoryHeaderProcess(tokens, headerField, mandatoryHeader);
 		else
 		{
@@ -150,71 +127,50 @@ void	RequestLexer::headerLineTokenize(Tokens &tokens)
 	}
 }
 
-void	RequestLexer::bodyLineTokenize(Tokens &tokens)
+void	RequestLexer::bodyLineDoTokenize(Tokens &tokens, const std::string &requestMessage)
 {
 	std::string body;
 	SizeType len;
 
 	len = requestMessage.length();
-	if (requestMessage.find(g_CRLF) == 0)
+	if (requestMessage.find(CRLF) == 0)
 		body = requestMessage.substr(2, len);
 	else
 		body = requestMessage;
 	tokens.push_back(std::make_pair(BODY, body));
 }
 
-void	RequestLexer::errorHandling(Tokens &tokens, const char *code)
+void	RequestLexer::errorHandling(Tokens &tokens, const std::string &code)
 {
 	tokens.empty();
 	tokens.push_back(std::make_pair(ERROR, code)); //code가 char형인데 되는지 모르겠음. 여기는 string
 }
 
-RequestLexer::Tokens RequestLexer::httpTokenize(std::string inputRequestMessage)	
+RequestLexer::Tokens RequestLexer::startLineHeaderLineTokenize(std::string &requestMessage)
 {
 	Tokens	tokens;
 
-	requestMessage = inputRequestMessage;
 	try
 	{
-		RequestLexer::startLineTokenize(tokens);
-		RequestLexer::headerLineTokenize(tokens);
-		RequestLexer::bodyLineTokenize(tokens);
+		RequestLexer::startLineTokenize(tokens,  requestMessage);
+		RequestLexer::headerLineTokenize(tokens, requestMessage);
 	}
-	catch(const char *code)
+	catch(const std::string &code)
 	{
 		errorHandling(tokens, code);
 	}
 	return (tokens);
 }
 
-
-RequestLexer::Tokens RequestLexer::startLineHeaderLineTokenize(const std::string &inputRequestMessage)
+RequestLexer::Tokens RequestLexer::bodyLineTokenize(const std::string &requestMessage)
 {
 	Tokens	tokens;
 
-	requestMessage = inputRequestMessage;
 	try
 	{
-		RequestLexer::startLineTokenize(tokens);
-		RequestLexer::headerLineTokenize(tokens);
+		RequestLexer::bodyLineDoTokenize(tokens, requestMessage);
 	}
-	catch(const char *code)
-	{
-		errorHandling(tokens, code);
-	}
-	return (tokens);
-}
-
-RequestLexer::Tokens RequestLexer::bodyLineTokenize(const std::string &inputRequestMessage)
-{
-	Tokens	tokens;
-
-	requestMessage = inputRequestMessage;
-	try
-	{
-		RequestLexer::bodyLineTokenize(tokens);
-	}
-	catch(const char *code)
+	catch(const std::string &code)
 	{
 		errorHandling(tokens, code);
 	}


### PR DESCRIPTION
- [x] 예외로 const char *가 아닌 const std::string을 value로 던지고 catch 문에서 그에 대한 레퍼런스를 잡도록 수정
- [x] const, & 타입으로 바꿀 수 있는 메서드 파라미터들의 타입 변환
- [x] static member variable 제거하고 메서드 인자로 전달하도록 수정
- [x] isDelimiter, isCRLF, isMandatoryHeader 제거
- [x] g_CRLF를 클래스 변수로 정의
- [x] (ft_tolower): 함수 간결화
- [x] (colonSplit): 지역 변수 len 제거
- [x] (getLine): substr 대신 erase 사용해 대입 과정 제거
- [x] (startLineTokenize): 불필요한 지역 변수 제거
- [x] (bodyLineTokenize(Token)): bodyLineDoTokenize로 이름 변경(추후 네이밍 컨벤션대로 동사가 먼저 나오게 함수명 수정 고려)
- [x] (headerLineTokenize): 현재 headerField가 mandatoryHeader에 있는지 확인하기 위해 std::map::count 대신 std::map::find를 활용하도록 수정