### PR TITLE
refactor: ResponseHandler, Response

### DIFF
--- a/Client/inc/Response.hpp
+++ b/Client/inc/Response.hpp
@@ -21,14 +21,14 @@ class Response
         bool        keepAlive;
 
     public:
-        std::string getStatusCode();
-        std::string getContentLength();
-        std::string getContentType();
-        std::string getBody();
-        std::string getDate();
-        std::string getLocation();
-        std::string getCookie();
-        bool        isKeepAlive();
+        std::string getStatusCode() const;
+        std::string getContentLength() const;
+        std::string getContentType() const;
+        std::string getBody() const;
+        std::string getDate() const;
+        std::string getLocation() const;
+        std::string getCookie() const;
+        bool        isKeepAlive() const;
 
         void setStatusCode(std::string statusCode);
         void setContentLength(std::string contentLength);

--- a/Client/src/Response.cpp
+++ b/Client/src/Response.cpp
@@ -6,7 +6,7 @@ Response::Response()
 
 }
 
-std::string Response::getStatusCode()
+std::string Response::getStatusCode() const
 {
     return this->statusCode;
 }
@@ -16,7 +16,7 @@ void Response::setStatusCode(std::string statusCode)
     this->statusCode = statusCode;
 }
 
-std::string Response::getContentLength()
+std::string Response::getContentLength() const
 {
     return this->contentLength;
 }
@@ -26,7 +26,7 @@ void Response::setContentLength(std::string contentLength)
     this->contentLength = contentLength;
 }
 
-std::string Response::getContentType()
+std::string Response::getContentType() const
 {
     return this->contentType;
 }
@@ -36,7 +36,7 @@ void Response::setContentType(std::string contentType)
     this->contentType = contentType;
 }
 
-std::string Response::getBody()
+std::string Response::getBody() const
 {
     return this->body;
 }
@@ -46,7 +46,7 @@ void Response::setBody(std::string body)
     this->body = body;
 }
 
-std::string Response::getDate()
+std::string Response::getDate() const
 {
     return this->date;
 }
@@ -56,7 +56,7 @@ void Response::setDate(std::string date)
     this->date = date;
 }
 
-std::string Response::getLocation()
+std::string Response::getLocation() const
 {
     return this->location;
 }
@@ -66,7 +66,7 @@ void Response::setLocation(std::string location)
     this->location = location;
 }
 
-std::string Response::getCookie()
+std::string Response::getCookie() const
 {
     return this->cookie;
 }
@@ -76,7 +76,7 @@ void Response::setCookie(std::string cookie)
     this->cookie = cookie;
 }
 
-bool Response::isKeepAlive()
+bool Response::isKeepAlive() const
 {
     return this->keepAlive;    
 }

--- a/RequestParser/inc/RequestParser.hpp
+++ b/RequestParser/inc/RequestParser.hpp
@@ -17,17 +17,18 @@ class RequestParser
   typedef RequestLexer::Tokens Tokens;
   typedef RequestLexer::Token Token;
   typedef RequestLexer::SizeType SizeType;
+  // typedef RequestLexer::StatusCode  StatusCode;
+  typedef std::string StatusCode;
   typedef std::string Space, HttpVersion, FieldName, FieldValue, Port, BodyType;
   typedef int HeaderType;
-
 
   private:
     //startline 검사
     static void startLineValidity(Tokens &tokens, Request &request);
     static void headerLineValidity(const Tokens &tokens, Request &request);
     static void bodyLineValidity(const Tokens &tokens, Request &request);
-    static void errorHandling(const char *code, Request &request);
-    static void throwError(const char *code, const std::string &errorReason);
+    static void errorHandling(const std::string &code, Request &request);
+    static void throwError(const std::string &code, const std::string &errorReason);
 
     static void previousErrorCheck(const Tokens &tokens);
     static bool isMethod(const std::string &str);
@@ -64,6 +65,7 @@ class RequestParser
   private:	// constants
     static const Space	SPACE;
     static const HttpVersion HTTPVERSION;
+    static const StatusCode CLIENT_ERROR;
 
   public:
     // static Request httpParser(Tokens &tokens);//TODO: remove

--- a/Server/inc/ResponseHandler.hpp
+++ b/Server/inc/ResponseHandler.hpp
@@ -27,34 +27,26 @@ class ResponseHandler
         typedef std::map<std::string, std::string> StatusTextMapType, ErrorPageLocationMapType;
 
     private:
-        static std::string ft_toLower(std::string str);
-        static bool isErrorStatusCode();
-        static ResponseMessageType createNormalMessage();
-        static ResponseMessageType createErrorMessage();
-        static BodyType getErrorPageBody();
+        static std::string &ft_toLower(std::string &str);
+        static bool isErrorStatusCode(const Response &response);
+        static ResponseMessageType createNormalMessage(const Response &response);
+        static BodyType getErrorPageBody(const Response &response);
 
-        static StartLineType createStartLine();
-        static StatusTextMapType initialStatusTextMap();
+        static StartLineType createStartLine(const Response &response);
 
-        static HeaderLineType createHeaderLine();
+        static HeaderLineType createHeaderLine(const Response &response);
         static DateType getCurrentTime();
-        static ContentLengthType getContentLength();
-        static std::string sizet_to_string(size_t value);
-        static CookieStringType getCookieString();
-        static bool isRedirectStatusCode();
-        static RedirectLocationType createRedirectLocation();
-        static bool isKeepAlive();
-        static KeepAliveType createKeepAlive();
+        static ContentLengthType getContentLength(const Response &response);
+        static std::string sizet_to_string(const size_t value);
+        static CookieStringType getCookieString(const Response &response);
+        static bool isRedirectStatusCode(const Response &response);
+        static RedirectLocationType createRedirectLocation(const Response &response);
+        static bool isKeepAlive(const Response &response);
+        static KeepAliveType createKeepAlive(const Response &response);
 
-        static BodyType createBody();        
-        static ResponseMessageType pasteAll(StartLineType &startLine, HeaderLineType &headerLine, BodyType &body);
-
-        static bool isSetCookieHeader(std::string str);
-        static bool isContentTypeHeader(std::string str);
+        static bool isSetCookieHeader(std::string &str);
+        static bool isContentTypeHeader(std::string &str);
         static void cgiBodySetting(Response &inputResponse);
-        
-    private:        
-		static Response	response;
 
     public:
         static void cgiMessageParsing(Response &inputResponse);

--- a/Server/src/ResponseHandler.cpp
+++ b/Server/src/ResponseHandler.cpp
@@ -1,41 +1,30 @@
 #include "ResponseHandler.hpp"
+#include <algorithm>
 
-Response ResponseHandler::response;
-
-std::string ResponseHandler::ft_toLower(std::string str)
+std::string &ResponseHandler::ft_toLower(std::string &str)
 {
-  for (unsigned int i = 0; i < str.length(); i++) {
-    str[i] = std::tolower(str[i]);
-  }
+    std::for_each(str.begin(), str.end(), ::tolower);
 	return str;
 }
 
-bool ResponseHandler::isErrorStatusCode()
+bool ResponseHandler::isErrorStatusCode(const Response &response)
 {
     Response::StatusCodeType statusCode = response.getStatusCode();
-    if (statusCode.find("4") == 0 || statusCode.find("5") == 0)
-        return true;
-    return false;
+
+    return (statusCode.find("4") == 0 || statusCode.find("5") == 0);
 }
 
-ResponseHandler::StatusTextMapType ResponseHandler::initialStatusTextMap()
-{
-    return StatusText().getStatusTextMap();
-}
-
-ResponseHandler::StartLineType ResponseHandler::createStartLine()
+ResponseHandler::StartLineType ResponseHandler::createStartLine(const Response &response)
 {
     StartLineType startLine = "";
-    StatusTextMapType statusTextMap = initialStatusTextMap();
-
+    StatusTextMapType statusTextMap = StatusText().getStatusTextMap();
+    StatusCodeType  statusCode = response.getStatusCode();
 
     startLine += HTTP_VERSION;
     startLine += SP;
-    if (statusTextMap.count(response.getStatusCode()) == 0)
-        std::cout << "code : " << response.getStatusCode() << " doesn't exist in the statusTextMap." << std::endl;
-    startLine += response.getStatusCode();
+    startLine += statusCode;
     startLine += SP;
-    startLine += statusTextMap[response.getStatusCode()];
+    startLine += statusTextMap[statusCode];
     startLine += CRLF;
 
     return startLine;
@@ -53,19 +42,19 @@ ResponseHandler::DateType ResponseHandler::getCurrentTime() {
     return currentTime;
 }
 
-std::string ResponseHandler::sizet_to_string(size_t value) 
+std::string ResponseHandler::sizet_to_string(const size_t value) 
 {
     std::stringstream ss;
     ss << value;
     return ss.str();
 }
 
-ResponseHandler::ContentLengthType ResponseHandler::getContentLength()
+ResponseHandler::ContentLengthType ResponseHandler::getContentLength(const Response &response)
 {
     return sizet_to_string(response.getBody().length());    
 }
 
-ResponseHandler::CookieStringType ResponseHandler::getCookieString()
+ResponseHandler::CookieStringType ResponseHandler::getCookieString(const Response &response)
 {
     ResponseHandler::CookieStringType cookieString = "";
     cookieString = response.getCookie();
@@ -74,15 +63,12 @@ ResponseHandler::CookieStringType ResponseHandler::getCookieString()
     return cookieString;
 }
 
-bool ResponseHandler::isRedirectStatusCode()
+bool ResponseHandler::isRedirectStatusCode(const Response &response)
 {
-    Response::StatusCodeType statusCode = response.getStatusCode();
-    if (statusCode.find("3") == 0)
-        return true;
-    return false;
+    return (response.getStatusCode().find("3") == 0);
 }
 
-ResponseHandler::RedirectLocationType ResponseHandler::createRedirectLocation()
+ResponseHandler::RedirectLocationType ResponseHandler::createRedirectLocation(const Response &response)
 {
     ResponseHandler::RedirectLocationType redirectLocation = "";
 
@@ -92,16 +78,16 @@ ResponseHandler::RedirectLocationType ResponseHandler::createRedirectLocation()
     return redirectLocation;
 }
 
-bool ResponseHandler::isKeepAlive()
+bool ResponseHandler::isKeepAlive(const Response &response)
 {
     return response.isKeepAlive();
 }
 
-ResponseHandler::KeepAliveType ResponseHandler::createKeepAlive()
+ResponseHandler::KeepAliveType ResponseHandler::createKeepAlive(const Response &response)
 {
     std::string connection;
 
-    if (isKeepAlive())
+    if (isKeepAlive(response))
         connection = "Connection: Keep-Alive";
     else
         connection = "Connection: close";
@@ -109,7 +95,7 @@ ResponseHandler::KeepAliveType ResponseHandler::createKeepAlive()
     return connection;
 }
 
-ResponseHandler::HeaderLineType ResponseHandler::createHeaderLine()
+ResponseHandler::HeaderLineType ResponseHandler::createHeaderLine(const Response &response)
 {
     HeaderLineType headerLine = "";
     DateType currentTime = getCurrentTime();
@@ -125,51 +111,36 @@ ResponseHandler::HeaderLineType ResponseHandler::createHeaderLine()
 
     //content-length
     headerLine += "Content-Length: ";
-    headerLine += getContentLength();
+    headerLine += getContentLength(response);
     headerLine += CRLF;
     
     //cookie
-    headerLine += getCookieString();
+    headerLine += getCookieString(response);
     
     //redirection
-    if (isRedirectStatusCode())
-        headerLine += createRedirectLocation();
+    if (isRedirectStatusCode(response))
+        headerLine += createRedirectLocation(response);
 
     //Connection(keepAlive)
-    headerLine += createKeepAlive();
+    headerLine += createKeepAlive(response);
     
     //last CRLF
     headerLine += CRLF;
     return headerLine;
 }
 
-ResponseHandler::BodyType ResponseHandler::createBody()
-{
-    return response.getBody();
-}
-
-ResponseHandler::ResponseMessageType ResponseHandler::pasteAll(StartLineType &startLine, HeaderLineType &headerLine, BodyType &body)
-{
-    ResponseMessageType responseMessage;
-
-    responseMessage += startLine;
-    responseMessage += headerLine;
-    responseMessage += body;
-    return responseMessage;
-}
-
-ResponseHandler::ResponseMessageType ResponseHandler::createNormalMessage()
+ResponseHandler::ResponseMessageType ResponseHandler::createNormalMessage(const Response &response)
 {
     ResponseMessageType responseMessage, startLine, headerLine, body;
 
-    startLine = createStartLine();
-    headerLine = createHeaderLine();
-    body = createBody();
-    responseMessage = pasteAll(startLine, headerLine, body);
+    startLine = createStartLine(response);
+    headerLine = createHeaderLine(response);
+    body = response.getBody();
+    responseMessage = startLine + headerLine + body;
     return responseMessage;
 }
 
-ResponseHandler::BodyType ResponseHandler::getErrorPageBody()
+ResponseHandler::BodyType ResponseHandler::getErrorPageBody(const Response &response)
 {
     std::string fileLocation = ERROR_PAGE_LOCATION + response.getStatusCode() + ".html";
     std::ifstream file(fileLocation.c_str());
@@ -178,38 +149,17 @@ ResponseHandler::BodyType ResponseHandler::getErrorPageBody()
     return buffer.str();
 }
 
-ResponseHandler::ResponseMessageType ResponseHandler::createErrorMessage()
+ResponseHandler::ResponseMessageType ResponseHandler::createResponseMessage(const Response &response)
 {
-    ResponseMessageType errorMessage, startLine, headerLine, body;
-
-    startLine = createStartLine();
-    // body = getErrorPageBody();
-    // response.setBody(body); //content Length가 header쪽에서 response body를 보고 바껴서 body와 header 순서를 바꿔줌.
-    body = response.getBody();
-    headerLine = createHeaderLine();
-    errorMessage = pasteAll(startLine, headerLine, body);
-    return errorMessage;
+    return (createNormalMessage(response));
 }
 
-ResponseHandler::ResponseMessageType ResponseHandler::createResponseMessage(const Response &inputResponseMessage)
-{
-    ResponseMessageType outputResponseMessage;
-    
-    response = inputResponseMessage;
-    // if (!isErrorStatusCode())
-    outputResponseMessage = createNormalMessage();
-    // else
-    //     outputResponseMessage = createErrorMessage();
-    return outputResponseMessage; 
-}
-
-
-bool ResponseHandler::isSetCookieHeader(std::string str)
+bool ResponseHandler::isSetCookieHeader(std::string &str)
 {
     return (ft_toLower(str).find("set-cookie: ") == 0);
 }
 
-bool ResponseHandler::isContentTypeHeader(std::string str)
+bool ResponseHandler::isContentTypeHeader(std::string &str)
 {
     return (ft_toLower(str).find("content-type: ") == 0);
 }


### PR DESCRIPTION
- [x] (ResponseHandler): static class variable 제거하고 함수 인자로 전달하도록 수정
- [x] (ResponseHandler): const, & 타입으로 바꿀 수 있는 함수 파라미터들의 타입 변환
- [x] (ResponseHandler::initialStatusTextMap): 제거
- [x] (ResponseHandler::ft_toLower): 함수 간결화
- [x] (ResponseHandler::createStartLine): 반복된 함수 호출 최소화 및 std::map::count 대신 std::map::find 활용
- [x] (ResponseHandler::createBody): 제거
- [x] (ResponseHandler::createErrorMessage): 제거
- [x] (ResponseHandler::pasteAll): 제거
- [x] (ResponseHandler::createResponseMessage): 함수 간결화
- [x] (ResponseHandler::isErrorStatusCode): 함수 간결화
- [x] (ResponseHandler::isRedirectStatusCode): 함수 간결화
- [x] (Response): getter들을 const method로 변환