### PR TITLE
fix: 클라이언트 연결과 관련한 로직 수정

### DIFF
--- a/Server/inc/Server.hpp
+++ b/Server/inc/Server.hpp
@@ -65,11 +65,12 @@ private:
 	void			receiveCGI(const FileDescriptor &epoll, const FileDescriptor &pipe, Client &target);
 	void			processRequest(const FileDescriptor &epoll, const FileDescriptor &client, Client &target);
 	void			sendData(const FileDescriptor &epoll, const FileDescriptor &client);
-	void			receiveData(const FileDescriptor &epoll, const FileDescriptor &fd, Client &target);
+	void			receiveData(const FileDescriptor &epoll, const FileDescriptor &fd, Client &target, bool isClient);
 	void			handleConnection(const FileDescriptor &epoll, const FileDescriptor &client);
 	void			destructClients();
 	template <typename MapType>
 	void			closeFileDescriptor(MapType &mapObject, const FileDescriptor &epoll);
+	void			disconnectPipe(const FileDescriptor &epoll, const FileDescriptor &client);
 
 public:
 	Server(const Config config);


### PR DESCRIPTION
1. receiveData에 client socket인지 cgi pipe인지 구분하기 위한 파라미터 추가
2. cgi pipe를 처리할 때 정상적으로 처리가 되었거나 관련한 클라이언트가 연결이 끊긴 상황일 때 모두 pipe를 닫도록 로직 추가
3. user agent가 연결을 끊으면 해당 Client instance의 상태가 어떻든 연결을 끊고 소켓을 닫는 로직 추가