### PR TITLE
fix: CGI 처리 과정 중 예외 처리 로직 추가

### DIFF
--- a/Client/inc/Client.hpp
+++ b/Client/inc/Client.hpp
@@ -15,6 +15,7 @@
 # define STATE_RESPONSE_CGI					8
 # define STATE_COMPLETE						16
 # define STATE_DISCONNECTED					32
+# define STATE_CHILD_PROCESS_ERROR			64
 
 # define CONTENT_LENGTH_EXCEPTION_MESSAGE	"TOO LONG CLIENT MESSAGE BODY!"
 
@@ -70,8 +71,10 @@ public:
 	
 	void				setCGIState();
 	void				setDisconnectedState();
+	void				setChildProcessErrorState();
 	bool				isComplete();
 	bool				isDisconnected();
+	bool				isChildProcessError();
 
 	bool				isKeepAlive();
 	void				reset();

--- a/Client/src/Client.cpp
+++ b/Client/src/Client.cpp
@@ -110,9 +110,19 @@ void Client::setDisconnectedState()
 	state = STATE_DISCONNECTED;
 }
 
+void Client::setChildProcessErrorState()
+{
+	state = STATE_CHILD_PROCESS_ERROR;
+}
+
 bool Client::isDisconnected()
 {
 	return (state == STATE_DISCONNECTED);
+}
+
+bool Client::isChildProcessError()
+{
+	return (state == STATE_CHILD_PROCESS_ERROR);
 }
 
 const Request &Client::getRequestObject()

--- a/Server/inc/RequestHandler.hpp
+++ b/Server/inc/RequestHandler.hpp
@@ -41,8 +41,7 @@ class RequestHandler
         RequestHandler();
         static std::string createDirectoryListing(PathType path);
         static std::string getDirectoryList(PathType path);
-        static Response processLocation(int &fd, const ConfigLocation &location, Route route, const Request &request);     
-        static std::string getFile(PathType path);
+        static Response processLocation(int &fd, const ConfigLocation &location, Route route, const Request &request);
         static std::string readFileToString(const Path &filePath);
         static Response responseError(std::string statusCode, ErrorPageMap errorPage);
         static Response responseRedirect(std::vector<std::string> redirect);
@@ -61,6 +60,13 @@ class RequestHandler
         static bool     isDirectoryFile(const Path requestPath);
         static void     tokenizeUriPath(std::vector<std::string> &tokens, Path uriPath);
         static bool     resolveRerativePath(Request &request);
+        static Path     determinePath(const ConfigLocation &location, Route route, const Request &request);
+        static Response processPath(int &fd, const ConfigLocation location, const Path requestPath, const Request &request);
+        static Response processDirectory(int &fd, const ConfigLocation location, const Path requestPath, const Request &request);
+        static Response processFile(int &fd, const ConfigLocation location, const Path requestPath, const Request &request);
+
+
+
     public:
         static  Response    responseError(std::string statusCode);
         static  Response    processRequest(int &fd, const SocketAddr &socketaddr, const Config &config, Request &request);

--- a/Server/inc/Server.hpp
+++ b/Server/inc/Server.hpp
@@ -10,20 +10,21 @@
 # include "Config.hpp"
 # include "Client.hpp"
 
-# define LOCALHOST_STR					"localhost"
-# define LOCALHOST_NUMERIC_STR			"127.0.0.1"
-# define ASTERISK_STR					"*"
-# define ASTERISK_NUMERIC_STR			NULL
-# define MAX_EVENT_COUNT				10
-# define BUFFER_SIZE					8000
-# define CHAR_NULL						'\0'
-# define RECV_EXCEPTION_MESSAGE			"recv() ERROR!"
-# define READ_EXCEPTION_MESSAGE			"read() ERROR!"
-# define SEND_EXCEPTION_MESSAGE			"send() ERROR!"
-# define DISCONNECTED_MESSAGE			"CLIENT DISCONNECTED!"
-# define DISCONNECTING_MESSAGE			"SERVER DISCONNECTED!"
-# define ACCEPT_EXCEPTION_MESSAGE		"accept() ERROR!"
-# define EPOLL_WAIT_EXCEPTION_MESSAGE	"epoll_wait() ERROR!"
+# define LOCALHOST_STR						"localhost"
+# define LOCALHOST_NUMERIC_STR				"127.0.0.1"
+# define ASTERISK_STR						"*"
+# define ASTERISK_NUMERIC_STR				NULL
+# define MAX_EVENT_COUNT					10
+# define BUFFER_SIZE						8000
+# define CHAR_NULL							'\0'
+# define RECV_EXCEPTION_MESSAGE				"recv() ERROR!"
+# define READ_EXCEPTION_MESSAGE				"read() ERROR!"
+# define SEND_EXCEPTION_MESSAGE				"send() ERROR!"
+# define DISCONNECTED_MESSAGE				"CLIENT DISCONNECTED!"
+# define DISCONNECTING_MESSAGE				"SERVER DISCONNECTED!"
+# define ACCEPT_EXCEPTION_MESSAGE			"accept() ERROR!"
+# define EPOLL_WAIT_EXCEPTION_MESSAGE		"epoll_wait() ERROR!"
+# define CHILD_PROCESS_EXCEPTION_MESSAGE	"child process ERROR!"
 
 class Server
 {

--- a/Server/inc/Server.hpp
+++ b/Server/inc/Server.hpp
@@ -25,7 +25,7 @@
 # define ACCEPT_EXCEPTION_MESSAGE			"accept() ERROR!"
 # define EPOLL_WAIT_EXCEPTION_MESSAGE		"epoll_wait() ERROR!"
 # define CHILD_PROCESS_EXCEPTION_MESSAGE	"child process ERROR!"
-
+# define PIPE_WRITE_EXCEPTION_MESSAGE		"pipe write ERROR!"
 class Server
 {
 public:

--- a/Server/inc/Server.hpp
+++ b/Server/inc/Server.hpp
@@ -52,7 +52,6 @@ private:
 	void			doListen(const FileDescriptor socket, addrinfo *result);
 	FileDescriptor	createSocket();
 	addrinfo		createaddrHints();
-	void			throwException(addrinfo *info);
 	const char		*extractNumericHost(const Host &host);
 	void			initServerSockets();
 	FileDescriptor	createEpollObject();

--- a/Server/src/RequestHandler.cpp
+++ b/Server/src/RequestHandler.cpp
@@ -334,9 +334,9 @@ Response RequestHandler::processPath(int &fd, const ConfigLocation location, con
 
 Response RequestHandler::processDirectory(int & fd, const ConfigLocation location, const Path requestPath, const Request & request)
 {
-    if (access(requestPath.c_str(), X_OK | R_OK) == 0)
+    if (access(requestPath.c_str(), R_OK) == 0)
         return (responseIndex(fd, location, requestPath, request));
-    
+    return (responseError("403", location.getErrorPage()));
 }
 
 Response RequestHandler::processFile(int & fd, const ConfigLocation location, const Path requestPath, const Request & request)

--- a/Server/src/RequestHandler.cpp
+++ b/Server/src/RequestHandler.cpp
@@ -251,7 +251,7 @@ Response    RequestHandler::processLocation(int &fd, const ConfigLocation &locat
         return responseError("403", location.getErrorPage());
     path = determinePath(location, route, request);
     if (stat(path.c_str(), &sb) == -1)
-        return (responseError("404"));
+        return (responseError("404", location.getErrorPage()));
     return (processPath(fd, location, path, request));
 }
 

--- a/Server/src/RequestHandler.cpp
+++ b/Server/src/RequestHandler.cpp
@@ -1,6 +1,7 @@
 #include "RequestHandler.hpp"
 #include <csignal>
 #include <sys/wait.h>
+#include <sys/stat.h>
 
 std::string RequestHandler::readFileToString(const Path &filePath){
     std::ifstream   file(filePath.c_str());
@@ -68,24 +69,6 @@ Response    RequestHandler::responseAutoIndex(const ConfigLocation location, con
     response.setBody(createDirectoryListing(requestPath));
     response.setKeepAlive(request.getKeepAlive());
     return response;
-}
-
-Response    RequestHandler::responseIndex(int &fd, const ConfigLocation location, const Path requestPath, const Request &request){
-    Path temp;
-    std::vector<std::string>::const_iterator index;
-    const std::vector<std::string> &indexList = location.getIndex();
-
-    for(index = indexList.begin(); index != indexList.end(); ++index){
-        temp = requestPath + *index;
-        if (access(temp.c_str(), F_OK) == 0){
-            if (isCGIPath(temp))
-                return responseCGI(fd, location, temp, request);
-            return responseFile(location, temp, request);
-        }
-    }
-    if (location.isAutoIndexOn())
-        return responseAutoIndex(location, requestPath, request);
-    return responseError("404", location.getErrorPage());
 }
 
 bool    RequestHandler::isAllowed(const ArgumentList  &limitExcept, const std::string method){
@@ -200,7 +183,7 @@ Response    RequestHandler::responseCGI(int &fd, const ConfigLocation &location,
     std::string requestBody = request.getBody();
 
     if (access(requestPath.c_str(), F_OK) != 0)
-        return responseError("404", location.getErrorPage());
+        return responseError("403", location.getErrorPage());
     if (pipe(pipefd) < 0 || pipe(pipefd + 2) < 0)
         std::cerr << "PIPE ERROR" << std::endl; // FIXME exit or exception? or 5XX responseError => pipe ERROR about FD.
     pid = fork();
@@ -224,7 +207,11 @@ Response    RequestHandler::responseCGI(int &fd, const ConfigLocation &location,
 }
 
 bool    RequestHandler::isDirectoryFile(const Path requestPath){
-    return (opendir(requestPath.c_str()) != NULL);
+    DIR *dir = opendir(requestPath.c_str());
+    if (dir == NULL)
+        return (false);
+    closedir(dir);
+    return (true);
 }
 
 std::string RequestHandler::getFileExtension(const Path path){
@@ -237,8 +224,6 @@ Response    RequestHandler::responseFile(const  ConfigLocation &location, const 
     Response    response;
     MIMEType::MIMEMap::const_iterator it;
 
-    if (access(requestPath.c_str(), F_OK) != 0)
-        return responseError("404", location.getErrorPage());
     if (request.getMethod() != "GET")
         return responseError("405", location.getErrorPage());
     if (isDirectoryFile(requestPath))
@@ -257,21 +242,17 @@ Response    RequestHandler::responseFile(const  ConfigLocation &location, const 
 }
 
 Response    RequestHandler::processLocation(int &fd, const ConfigLocation &location, Route route, const Request &request){
-    Path requestPath;
+    Path        path;
+    struct stat sb;
 
     if (isRequestBodyTooLarge(location.getClientMaxBodySize(), request.getContentLength()))
         return responseError("413", location.getErrorPage());
     if (!isAllowed(location.getLimitExcept(), request.getMethod()))
         return responseError("403", location.getErrorPage());
-    if (location.hasAlias())
-        requestPath = location.getAlias() + request.getUriPath().erase(0, route.length());
-    else
-        requestPath = ROOT_PATH + request.getUriPath();
-    if (isDirectoryPath(requestPath))
-        return responseIndex(fd, location, requestPath, request);
-    if (isCGIPath(requestPath))
-        return responseCGI(fd, location, requestPath, request);
-    return responseFile(location, requestPath, request);
+    path = determinePath(location, route, request);
+    if (stat(path.c_str(), &sb) == -1)
+        return (responseError("404"));
+    return (processPath(fd, location, path, request));
 }
 
 void   RequestHandler::tokenizeUriPath(std::vector<std::string> &tokens, Path uriPath){
@@ -318,6 +299,53 @@ bool    RequestHandler::resolveRerativePath(Request &request){
     request.setUriPath(uriPath);
     return true;
 }
+
+RequestHandler::Path RequestHandler::determinePath(const ConfigLocation &location, Route route, const Request &request)
+{
+    if (location.hasAlias())
+        return (location.getAlias() + request.getUriPath().erase(0, route.length()));
+    return (ROOT_PATH + request.getUriPath());
+}
+
+Response    RequestHandler::responseIndex(int &fd, const ConfigLocation location, const Path requestPath, const Request &request){
+    Path temp;
+    std::vector<std::string>::const_iterator index;
+    const std::vector<std::string> &indexList = location.getIndex();
+
+    for(index = indexList.begin(); index != indexList.end(); ++index){
+        temp = requestPath + *index;
+        if (access(temp.c_str(), F_OK) == 0){
+            if (isCGIPath(temp))
+                return responseCGI(fd, location, temp, request);
+            return responseFile(location, temp, request);
+        }
+    }
+    if (location.isAutoIndexOn())
+        return responseAutoIndex(location, requestPath, request);
+    return responseError("403", location.getErrorPage());
+}
+
+Response RequestHandler::processPath(int &fd, const ConfigLocation location, const Path requestPath, const Request &request)
+{
+    if (isDirectoryPath(requestPath))
+        return (processDirectory(fd, location, requestPath, request));
+    return (processFile(fd, location, requestPath, request));
+}
+
+Response RequestHandler::processDirectory(int & fd, const ConfigLocation location, const Path requestPath, const Request & request)
+{
+    if (access(requestPath.c_str(), X_OK | R_OK) == 0)
+        return (responseIndex(fd, location, requestPath, request));
+    
+}
+
+Response RequestHandler::processFile(int & fd, const ConfigLocation location, const Path requestPath, const Request & request)
+{
+    if (isCGIPath(requestPath))
+        return (responseCGI(fd, location, requestPath, request));
+    return (responseFile(location, requestPath, request));
+}
+
 
 Response    RequestHandler::processRequest(int &fd, const SocketAddr &socketaddr, const Config &config, Request &request){
     const ConfigServer              &server = config.getServer(socketaddr, request.getHost());

--- a/Server/src/Server.cpp
+++ b/Server/src/Server.cpp
@@ -76,12 +76,6 @@ addrinfo Server::createaddrHints()
 	return (hints);
 }
 
-void Server::throwException(addrinfo *info)
-{
-	freeaddrinfo(info);
-	throw (std::runtime_error(std::strerror(errno)));
-}
-
 const char	*Server::extractNumericHost(const Host &host)
 {
     if (host == LOCALHOST_STR)

--- a/Server/src/Server.cpp
+++ b/Server/src/Server.cpp
@@ -206,6 +206,8 @@ void Server::processRequest(const FileDescriptor &epoll, const FileDescriptor &c
 	target.setResponseObject(RequestHandler::processRequest(cgiPipe, *(connection[client]), config, const_cast<Request &>(target.getRequestObject())));
 	if (cgiPipe == 0)
 		return (target.setResponseMessageBuffer(ResponseHandler::createResponseMessage(target.getResponseObject())));
+	if (cgiPipe == -1)
+		return (disconnect(epoll, client, PIPE_WRITE_EXCEPTION_MESSAGE));
 	fcntl(cgiPipe, F_SETFL, O_NONBLOCK); // Without this, cgiPipe must be blocking.
 	controlIOEvent(epoll, EPOLL_CTL_ADD, cgiPipe, EPOLLIN);
 	cgiClients[cgiPipe] = &target;


### PR DESCRIPTION
- [x] 자식 프로세스에서 시스템 오류가 생겼을 때, 서버에서 해당 클라이언트를 제거하게 로직 수정
- [x] 서버에서 CGI에 write 시스템 콜을 할 때 예외가 발생하면 연관된 클라이언트의 연결을 끊고 서버의 동작은 유지하게 수정